### PR TITLE
XDR-373: No longer create empty bgp_settings when enable_bgp is false

### DIFF
--- a/modules/azure-virtual-network-gateway/main.tf
+++ b/modules/azure-virtual-network-gateway/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_virtual_network_gateway" "gateway" {
       vpn_client_protocols = var.vpn_client_protocols
 
       dynamic "root_certificate" {
-        for_each = var.vpn_root_certificate_name != null ? [1] : [0]
+        for_each = var.vpn_root_certificate_name != null ? [1] : []
 
         content {
           name             = var.vpn_root_certificate_name


### PR DESCRIPTION
When applied with `var.enabled_bgp` set to `false` the azurerm provider is throwing:

```
Error: bgp_settings.0.peering_addresses.0.apipa_addresses: attribute supports 1 item as a minimum, config has 0 declared

  on .terraform/modules/vpn_gateway/modules/azure-virtual-network-gateway/main.tf line 16, in resource "azurerm_virtual_network_gateway" "gateway":
  16: resource "azurerm_virtual_network_gateway" "gateway" {

Error: "bgp_settings.0.peering_addresses.0.default_addresses": this field cannot be set

  on .terraform/modules/vpn_gateway/modules/azure-virtual-network-gateway/main.tf line 16, in resource "azurerm_virtual_network_gateway" "gateway":
  16: resource "azurerm_virtual_network_gateway" "gateway" {

Error: "bgp_settings.0.peering_addresses.0.tunnel_ip_addresses": this field cannot be set

  on .terraform/modules/vpn_gateway/modules/azure-virtual-network-gateway/main.tf line 16, in resource "azurerm_virtual_network_gateway" "gateway":
  16: resource "azurerm_virtual_network_gateway" "gateway" {
```

This is because the dynamic content was being created with a key of '0'
and values of `null`, which are no longer permitted by the provider.