### PR TITLE
XDR-7734: Drop module_variable_optional_attrs experiment

### DIFF
--- a/modules/azure-local-network-gateway/main.tf
+++ b/modules/azure-local-network-gateway/main.tf
@@ -3,14 +3,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 resource "azurerm_local_network_gateway" "remote" {

--- a/modules/azure-network-security-rule/main.tf
+++ b/modules/azure-network-security-rule/main.tf
@@ -3,14 +3,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 resource "azurerm_network_security_rule" "rule" {

--- a/modules/azure-subnet/main.tf
+++ b/modules/azure-subnet/main.tf
@@ -3,14 +3,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 resource "azurerm_subnet" "subnet" {

--- a/modules/azure-virtual-network-gateway-connection/main.tf
+++ b/modules/azure-virtual-network-gateway-connection/main.tf
@@ -3,14 +3,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 resource "azurerm_virtual_network_gateway_connection" "connection" {

--- a/modules/azure-virtual-network-gateway/main.tf
+++ b/modules/azure-virtual-network-gateway/main.tf
@@ -3,14 +3,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 resource "azurerm_virtual_network_gateway" "gateway" {


### PR DESCRIPTION
## Summary

Removes the concluded `module_variable_optional_attrs` language experiment from 5 submodules and bumps `required_version` from `>= 1.2` to `>= 1.3`. The feature was stabilized as `optional()` in Terraform 1.3, so declaring the experiment is a **hard error** on Terraform 1.3+ (`Experiment has concluded`).

## Context

Companion to [infrastructure-modules#541](https://github.com/quantum-sec/infrastructure-modules/pull/541) and the previous `package-acr` / `package-log-analytics` cleanups. Surfaced as a CI blocker on [infrastructure-live-staging#136](https://github.com/quantum-sec/infrastructure-live-staging/pull/136) when `azure-terraform-remote-state-private` — which consumes this repo's submodules at `?ref=2.0.6` — failed `terraform init` under Terraform 1.5.

## Breaking-change assessment

None. The only historical divergence between the experimental and stable `optional()` behavior was the experimental `defaults = { … }` argument, which none of these submodules used. Caller-facing impact: consumers still on Terraform 1.2.x must upgrade to 1.3+.

## Files changed (5)

- `modules/azure-local-network-gateway/main.tf`
- `modules/azure-network-security-rule/main.tf`
- `modules/azure-subnet/main.tf`
- `modules/azure-virtual-network-gateway/main.tf`
- `modules/azure-virtual-network-gateway-connection/main.tf`

The other submodules in this repo are already clean.

## Test plan

- [x] `pre-commit run --all-files` clean (all hooks pass)
- [ ] Cut a new tag (e.g. `2.0.7`) after merge; `infrastructure-modules` will auto-bump `?ref=2.0.6 → 2.0.7` across 21 lines in 6 files